### PR TITLE
ニコ生検索

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*
 !.gitignore
+__pycache__

--- a/nico.py
+++ b/nico.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import json
+from urllib.request import urlopen
+
+TAG = 'StarCraft2'
+LIMIT = 5
+
+# ニコ生検索
+# (title, url)のタプル配列を返す
+def search():
+    url = "http://api.search.nicovideo.jp/api/v2/live/contents/search"
+    url += "?q={}&targets=tags".format(TAG) # タグ
+    url += "&filters[liveStatus][0]=onair" # 放送中のみ
+    url += "&fields=contentId,title" # 欲しいデータ
+    url += "&_sort=-startTime" # 開始時間でソート
+    url += "&_limit={}".format(LIMIT) # 件数
+    url += "&_context=apiguide"
+    res = urlopen(url)
+    j = json.loads(res.read().decode('utf8'))
+    if j['meta']['status'] != 200:
+        return []
+    return [(x['title'], live_url(x['contentId'])) for x in j['data']]
+
+def live_url(content_id):
+    return 'http://live.nicovideo.jp/watch/' + content_id


### PR DESCRIPTION
ニコ生検索する関数だけ作りました。

searchが配列を返します。配列の各要素が(title, url)のタプルです。

```
import nico

a = nico.search()
for x in a:
    print(x[0] + ":" + x[1])
```

こんな感じでprintすると、

```
タイトル1:URL1
タイトル2:URL2
タイトル3:URL3
```

こうなります。

ニコ生はユーザ名が取れないっぽい？ので放送タイトルにしてますが、割と長い場合があるので今のままだとツイートが140字超えるかもしれません。件数は適当に調整してください。

参考: http://ch.nicovideo.jp/nico-lab/blomaga/ar930955/

あとはまかせた・・